### PR TITLE
update instantiation of DevTools to support v4

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,7 +16,7 @@ import { HttpClientModule } from '@angular/common/http';
     AppRoutingModule,
     TodosModule,
     HttpClientModule,
-    environment.production ? [] : AkitaNgDevtools.forRoot()
+    environment.production ? [] : AkitaNgDevtools
   ],
   providers: [],
   bootstrap: [AppComponent]


### PR DESCRIPTION
Just updating the instantiation of DevTools to remove forRoot() as this is no longer required.